### PR TITLE
Release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.1.3 (2019-04-05)
 
 - **[Feature]** Mark `from_epsilons` constructor as `const`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "swf-fixed"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-fixed"
-version = "0.1.2"
+version = "0.1.3"
 description = "SWF fixed-point numbers for Rust"
 documentation = "https://github.com/open-flash/rust-swf-fixed"
 homepage = "https://github.com/open-flash/rust-swf-fixed"


### PR DESCRIPTION
- **[Feature]** Mark `from_epsilons` constructor as `const`.