### PR TITLE
Add `clippy` support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,16 @@ language: rust
 os:
   - linux
 
+rust:
+  - stable
+
 before_script:
+  - rustup component add clippy
   - rustup component add rustfmt
 
 script:
   - cargo fmt --all -- --check
+  - cargo clippy --all-targets --all-features -- -D warnings
   - cargo build
   - cargo test
   - cargo test --no-default-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Next
 
 - **[Feature]** Move `serde` support into optional `serde` feature ([#19](https://github.com/open-flash/rust-swf-fixed/issues/19)).
-- **[Internal]** Add `rustfmt` integration.
+- **[Internal]** Add `rustfmt` support.
+- **[Internal]** Add `clippy` support.
 
 # 0.1.4 (2019-04-22)
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+# cargo clippy --all-targets --all-features -- -D warnings
+
+# (Using default config)

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
+# cargo fmt --all
 max_width = 120
 tab_spaces = 2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,15 +147,15 @@ mod tests {
     );
     assert_eq!(
       serde_json::from_str::<Sfixed16P16>("65536").unwrap(),
-      Sfixed16P16::from_epsilons(65536)
+      Sfixed16P16::from_epsilons(65_536)
     );
     assert_eq!(
       serde_json::from_str::<Sfixed16P16>("2147483647").unwrap(),
-      Sfixed16P16::from_epsilons(2147483647)
+      Sfixed16P16::from_epsilons(2_147_483_647)
     );
     assert_eq!(
       serde_json::from_str::<Sfixed16P16>("-2147483648").unwrap(),
-      Sfixed16P16::from_epsilons(-2147483648)
+      Sfixed16P16::from_epsilons(-2_147_483_648)
     );
   }
 
@@ -166,18 +166,30 @@ mod tests {
 
   #[test]
   fn test_ufixed8p8_value() {
-    assert_eq!(f32::from(Ufixed8P8::from_value(24f32)), 24f32);
-    assert_eq!(f32::from(Ufixed8P8::from_value(255f32)), 255f32);
+    assert_eq!(
+      f32::from(Ufixed8P8::from_value(24f32)).to_ne_bytes(),
+      24f32.to_ne_bytes()
+    );
+    assert_eq!(
+      f32::from(Ufixed8P8::from_value(255f32)).to_ne_bytes(),
+      255f32.to_ne_bytes()
+    );
   }
 
   #[test]
   fn test_sfixed8p8_value() {
-    assert_eq!(f32::from(Sfixed8P8::from_value(-24f32)), -24f32);
+    assert_eq!(
+      f32::from(Sfixed8P8::from_value(-24f32)).to_ne_bytes(),
+      (-24f32).to_ne_bytes()
+    );
   }
 
   #[test]
   fn test_ufixed16p16_value() {
-    assert_eq!(f64::from(Ufixed16P16::from_value(1000f64)), 1000f64);
+    assert_eq!(
+      f64::from(Ufixed16P16::from_value(1000f64)).to_ne_bytes(),
+      1000f64.to_ne_bytes()
+    );
   }
 
   #[test]
@@ -207,23 +219,23 @@ mod tests {
   #[test]
   fn test_add_ufixed8p8_ref() {
     assert_eq!(
-      &Ufixed8P8::from_value(0f32) + &Ufixed8P8::from_value(0f32),
+      Ufixed8P8::from_value(0f32) + Ufixed8P8::from_value(0f32),
       Ufixed8P8::from_value(0f32)
     );
     assert_eq!(
-      &Ufixed8P8::from_value(0f32) + &Ufixed8P8::from_value(1f32),
+      Ufixed8P8::from_value(0f32) + Ufixed8P8::from_value(1f32),
       Ufixed8P8::from_value(1f32)
     );
     assert_eq!(
-      &Ufixed8P8::from_value(1f32) + &Ufixed8P8::from_value(0f32),
+      Ufixed8P8::from_value(1f32) + Ufixed8P8::from_value(0f32),
       Ufixed8P8::from_value(1f32)
     );
     assert_eq!(
-      &Ufixed8P8::from_value(1f32) + &Ufixed8P8::from_value(1f32),
+      Ufixed8P8::from_value(1f32) + Ufixed8P8::from_value(1f32),
       Ufixed8P8::from_value(2f32)
     );
     assert_eq!(
-      &Ufixed8P8::from_value(0.5f32) + &Ufixed8P8::from_value(0.5f32),
+      Ufixed8P8::from_value(0.5f32) + Ufixed8P8::from_value(0.5f32),
       Ufixed8P8::from_value(1f32)
     );
   }


### PR DESCRIPTION
This commit adds a `clippy.toml` file to explicit mention clippy support. The code was updated to pass clippy check. Clippy was also enabled on Travis CI.

This PR also serves to check the migration to travis-ci.com