### PR TITLE
Release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Next
+# 0.1.5 (2020-03-06)
 
-- **[Feature]** Move `serde` support into optional `serde` feature ([#19](https://github.com/open-flash/rust-swf-fixed/issues/19)).
+- **[Feature]** Move `serde` support into optional `serde` feature (thanks [@SrKomodo](https://github.com/SrKomodo)) ([#19](https://github.com/open-flash/rust-swf-fixed/issues/19)).
 - **[Internal]** Add `rustfmt` support.
 - **[Internal]** Add `clippy` support.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "swf-fixed"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-fixed"
-version = "0.1.4"
+version = "0.1.5"
 description = "SWF fixed-point numbers for Rust"
 documentation = "https://github.com/open-flash/rust-swf-fixed"
 homepage = "https://github.com/open-flash/rust-swf-fixed"


### PR DESCRIPTION
- **[Feature]** Move `serde` support into optional `serde` feature (thanks [@SrKomodo](https://github.com/SrKomodo)) ([#19](https://github.com/open-flash/rust-swf-fixed/issues/19)).
- **[Internal]** Add `rustfmt` support.
- **[Internal]** Add `clippy` support.